### PR TITLE
v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![NPM Version](http://img.shields.io/npm/v/altnode.mixer-gain-node.svg?style=flat-square)](https://www.npmjs.org/package/altnode.mixer-gain-node)
 [![License](http://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](http://mohayonao.mit-license.org/)
 
+![graph](https://github.com/altnode/mixer-gain-node/wiki/images/mixer-gain-node.png)
+
 ## Installation
 
 ```
@@ -10,7 +12,7 @@ npm install -S altnode.mixer-gain-node
 ```
 
 ## API
-### AudioNode
+### MixerGainNode
 - `constructor(audioContext: AudioContext, numberOfInputs = 2)`
 
 #### Instance attributes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "altnode.mixer-gain-node",
   "description": "altnode.MixerGainNode",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Nao Yonamine <mohayonao@gmail.com>",
   "bugs": {
     "url": "https://github.com/altnode/mixer-gain-node/issues"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/altnode/mixer-gain-node/issues"
   },
   "dependencies": {
-    "altnode.audio-node": "^0.1.1"
+    "altnode.alt-audio-node": "^0.2.0"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/src/MixerGainNode.js
+++ b/src/MixerGainNode.js
@@ -1,7 +1,7 @@
-import AudioNode from "altnode.audio-node";
+import AltAudioNode from "altnode.alt-audio-node";
 import { CHANNELS } from "./symbols";
 
-export default class MixerGainNode extends AudioNode {
+export default class MixerGainNode extends AltAudioNode {
   constructor(audioContext, numberOfInputs = 2) {
     super(audioContext);
 


### PR DESCRIPTION
- use `altnode.AltAudioNode` instead of `altnode.AudioNode`
